### PR TITLE
refactor: Update `run` Method to Accept QA Objects in `BaseRAGFramework`

### DIFF
--- a/core/frameworks/base.py
+++ b/core/frameworks/base.py
@@ -101,14 +101,14 @@ class BaseRAGFramework(ABC):
                 raise ValueError("For InterDocumentQA datasets, please specify number_of_qas instead of number_of_docs")
             return self._load_inter_docs_and_qas(number_of_qas, selection_mode)
 
-    def run(self, query: str) -> RAGResponse:
+    def run(self, qa: IntraDocumentQA|InterDocumentQA) -> RAGResponse:
         """Run the RAG pipeline on a query."""
         try:
             # Retrieve relevant documents
-            retrieved_docs = self.retrieve(query)
+            retrieved_docs = self.retrieve(qa.q)
             
             # Generate answer
-            llm_answer = self.generate(query, retrieved_docs)
+            llm_answer = self.generate(qa.q, retrieved_docs)
             
             return llm_answer
             

--- a/test/simple_rag.py
+++ b/test/simple_rag.py
@@ -55,7 +55,7 @@ def qasper_test():
             logger.info(f"Testing RAG with query")
             response_list = []
             for qa in qas:
-                response = simple_rag.run(qa.q)
+                response = simple_rag.run(qa)
                 response_list.append(response)
             logger.info("RAG test completed")
 
@@ -88,7 +88,7 @@ def multihoprag_test():
         logger.info(f"Testing RAG with query")
         response_list = []
         for qa in gen_qas:
-            response = simple_rag.run(qa.q)
+            response = simple_rag.run(qa)
             response_list.append(response)
         logger.info("RAG test completed")
         


### PR DESCRIPTION
## 📝 Description
This pull request updates the `run` method in the `BaseRAGFramework` class to accept an `IntraDocumentQA` or `InterDocumentQA` object instead of a query string. The changes also update the test cases to pass the `qa` object directly to the `run` method.

## 🔗 Related Issue(s)
- #14 
- #18 

## 🔄 Type of Change
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)

## 📌 Additional Notes
- This update is for more efficient retrieval and generation evaluation later.
- This change modifies the method signature of `run`, which may affect other parts of the codebase that rely on this method. Ensure that all dependent code is updated accordingly.