### PR TITLE
fix `llm/controller.py`: Set tokenizers parallelism to avoid warnings during multiprocessing

### DIFF
--- a/core/rag_core/llm/controller.py
+++ b/core/rag_core/llm/controller.py
@@ -1,5 +1,9 @@
 # core/rag_core/llm/controller.py
 
+import os
+# Set tokenizers parallelism to avoid warnings when using multiprocessing
+os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
 import yaml
 from typing import Dict
 


### PR DESCRIPTION
## 📝 Description
Added environment variable setting to disable tokenizers parallelism in the LLM controller to prevent warnings when using multiprocessing.

## 🔗 Related Issue(s)
- #13

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 📌 Additional Notes
This PR addresses the HuggingFace tokenizers warning that was appearing when using multiprocessing. The warning occurred because tokenizers were initialized with parallelism before process forking, which could potentially lead to deadlocks. Setting `TOKENIZERS_PARALLELISM=false` explicitly prevents this issue.