### PR TITLE
feat: Modify RAG Framework Schemas for Clustering and Dimensional Reduction

### DIFF
--- a/core/frameworks/schema.py
+++ b/core/frameworks/schema.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, Field, PositiveInt
 from langchain_core.documents import Document
 
 # Available Models & Algorithms
-AVAILABLE_LLM_ID = Literal["llama3.1", "phi4", "deepseek-r1-8b", "deepseek-r1-14b"]
+AVAILABLE_LLM_ID = Literal["llama3.2:1b", "llama3.2:3b", "llama3.1", "phi4", "deepseek-r1-8b", "deepseek-r1-14b"]
 AVAILABLE_EMBEDDING_ID = Literal["huggingface-multi-qa-mpnet", "google-gecko"]
 AVAILABLE_FAISS_SEARCH = Literal["flatl2", "ivf", "hnsw"]
 AVAILABLE_DIM_REDUCTION = Literal["pca", "umap"]
@@ -32,6 +32,16 @@ class SummarizerConfig(BaseModel):
     output_tokens: PositiveInt = Field(..., description="Expected number of tokens to output")
     embedding_id: AVAILABLE_EMBEDDING_ID = Field(..., description="ID of the embedding model to use")
 
+class DimReductionConfig(BaseModel):
+    """Configuration for dimensionality reduction."""
+    method: AVAILABLE_DIM_REDUCTION = Field(..., description="Method for dimensionality reduction")
+    n_components: PositiveInt = Field(..., description="Number of components for dimensionality reduction")
+
+class ClusteringConfig(BaseModel):
+    """Configuration for clustering."""
+    method: AVAILABLE_CLUSTERING = Field(..., description="Clustering method to use")
+    n_clusters: Optional[PositiveInt] = Field(None, description="Number of clusters (if None, will be estimated)")
+
 class ChunkerConfig(BaseModel):
     """Configuration for the text chunking component."""
     mode: Literal["fixed"] = Field(..., description="Chunking mode (currently only fixed is supported)")
@@ -43,10 +53,8 @@ class ChunkerConfig(BaseModel):
         le=1.0
     )
     embedding_id: AVAILABLE_EMBEDDING_ID = Field(..., description="ID of the Embedding Model to use")
-    dim_reduction: Optional[AVAILABLE_DIM_REDUCTION] = Field(None, description="Method for dimensionality reduction (e.g., PCA, UMAP)")
-    n_components: Optional[PositiveInt] = Field(None, description="Number of components for dimensionality reduction")
-    clustering: Optional[AVAILABLE_CLUSTERING] = Field(None, description="Clustering method to use (e.g., k-means, GMM)")
-
+    dim_reduction: Optional[DimReductionConfig] = Field(None, description="Configuration for dimensionality reduction")
+    clustering: Optional[ClusteringConfig] = Field(None, description="Configuration for clustering")
 
 class RetrievalGenerationConfig(BaseModel):
     """Configuration for the retrieval component."""


### PR DESCRIPTION
## 📝 Description
This PR introduces schema changes to enhance model configuration and improve the organization of dimensionality reduction and clustering configurations. The changes include:

1. Added new LLaMA 3.2 models (1B and 3B variants) to available LLM options
2. Introduced dedicated Pydantic models for dimension reduction and clustering configurations
3. Refactored ChunkerConfig to use the new configuration models

## 🔗 Related Issue(s)
- #39 

## 🔄 Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation update

## 📌 Additional Notes
Breaking Changes:
1. ChunkerConfig's `dim_reduction` and `clustering` fields now expect structured configuration objects instead of simple literals
2. Applications using the previous schema will need to update their configuration format

Migration Guide:
New format:
```python
chunker_config = ChunkerConfig(
    dim_reduction=DimReductionConfig(
        method="pca",
        n_components=10
    ),
    clustering=ClusteringConfig(
        method="kmeans",
        n_clusters=5
    )
)
```