### PR TITLE
feat: Implement Simplified SCALER Framework for Inter-Document Search 

### DIFF
--- a/core/configs/scaler_v1_rag/comparison.yaml
+++ b/core/configs/scaler_v1_rag/comparison.yaml
@@ -1,0 +1,53 @@
+# core/configs/scaler_v1_rag/comparison.yaml
+
+# vs scaler_rag_01_03 at scaler_rag/scaler01_sentence_chunk.yaml
+scaler_v1_rag_01_01:
+  dataset:
+    name: frames
+  summarizer:
+    llm_id: llama3.2:1b
+    output_tokens: 512
+  chunker:
+    mode: fixed
+    size: 100
+    overlap: 0.2
+    embedding_id: huggingface-multi-qa-mpnet
+  retrieval_generation:
+    faiss_search: "flatl2"
+    top_k: 10
+    llm_id: llama3.1
+
+# vs scaler_rag_01_04 at scaler_rag/scaler01_sentence_chunk.yaml
+scaler_v1_rag_01_02:
+  dataset:
+    name: frames
+  summarizer:
+    llm_id: llama3.2:1b
+    output_tokens: 512
+  chunker:
+    mode: sentence
+    size: 100
+    overlap: 0.2
+    embedding_id: huggingface-multi-qa-mpnet
+  retrieval_generation:
+    faiss_search: "flatl2"
+    top_k: 10
+    llm_id: llama3.1
+
+  
+# vs scaler_rag_02_02 at scaler_rag/scaler02_reasoning_model.yaml
+scaler_v1_rag_01_03:
+  dataset:
+    name: frames
+  summarizer:
+    llm_id: deepseek-r1-8b
+    output_tokens: 512
+  chunker:
+    mode: sentence
+    size: 100
+    overlap: 0.2
+    embedding_id: huggingface-multi-qa-mpnet
+  retrieval_generation:
+    faiss_search: "flatl2"
+    top_k: 10
+    llm_id: deepseek-r1-8b

--- a/core/configs/scaler_v1_rag/test.yaml
+++ b/core/configs/scaler_v1_rag/test.yaml
@@ -1,0 +1,52 @@
+# core/configs/scaler_v1_rag/test.yaml
+
+# Experiment test
+TEST02_scaler_v1_rag_02:
+  dataset:
+    name: multihoprag
+    number_of_qas: 100
+  chunker:
+    mode: fixed
+    size: 100
+    overlap: 0.2
+    embedding_id: huggingface-multi-qa-mpnet
+  retrieval_generation:
+    faiss_search: "flatl2"
+    top_k: 10
+    llm_id: llama3.1
+
+TEST02_scaler_v1_rag_04:
+  dataset:
+    name: frames
+    number_of_qas: 50
+  chunker:
+    mode: fixed
+    size: 100
+    overlap: 0.2
+    embedding_id: huggingface-multi-qa-mpnet
+  retrieval_generation:
+    faiss_search: "flatl2"
+    top_k: 10
+    llm_id: llama3.1
+
+
+
+# Simple RAG test
+TEST_scaler_v1_rag_multihoprag:
+  dataset:
+    name: multihoprag
+    number_of_qas: 5
+    selection_mode: sequential
+  summarizer:
+    llm_id: llama3.2:1b
+    output_tokens: 512
+    embedding_id: huggingface-multi-qa-mpnet
+  chunker:
+    mode: fixed
+    size: 100
+    overlap: 0.2
+    embedding_id: huggingface-multi-qa-mpnet
+  retrieval_generation:
+    faiss_search: "flatl2"
+    top_k: 5
+    llm_id: llama3.1

--- a/core/configs/scaler_v1_rag/test.yaml
+++ b/core/configs/scaler_v1_rag/test.yaml
@@ -1,7 +1,7 @@
 # core/configs/scaler_v1_rag/test.yaml
 
 # Experiment test
-TEST02_scaler_v1_rag_02:
+TEST02_scaler_v1_rag_01:
   dataset:
     name: multihoprag
     number_of_qas: 100
@@ -15,7 +15,7 @@ TEST02_scaler_v1_rag_02:
     top_k: 10
     llm_id: llama3.1
 
-TEST02_scaler_v1_rag_04:
+TEST02_scaler_v1_rag_02:
   dataset:
     name: frames
     number_of_qas: 50

--- a/core/frameworks/__init__.py
+++ b/core/frameworks/__init__.py
@@ -3,10 +3,12 @@
 from .schema import RAGConfig, DatasetConfig, ChunkerConfig, RetrievalGenerationConfig, RAGResponse
 from .simple import SimpleRAG
 from .scaler import ScalerRAG
+from .scaler_v1 import ScalerV1RAG
 
 all = [
     "SimpleRAG",
     "ScalerRAG",
+    "ScalerV1RAG",
     "RAGConfig",
     "DatasetConfig",
     "ChunkerConfig",

--- a/core/frameworks/scaler_v1.py
+++ b/core/frameworks/scaler_v1.py
@@ -328,7 +328,7 @@ class ScalerV1RAG(BaseRAGFramework):
 
                 # if vectorsore is a single FAISS instance, use similarity_search_with_score
                 if isinstance(vectorstore, FAISS):
-                    results[layer] = vectorstore.similarity_search_by_vector(
+                    results[layer] = vectorstore.similarity_search_with_score_by_vector(
                         query_embedding,
                         k=top_k
                     )
@@ -338,14 +338,14 @@ class ScalerV1RAG(BaseRAGFramework):
                     # Initialize the results for the current layer
                     layer_results = []
                     # get the parent node ides from the previous layer
-                    parent_node_ids = [doc.metadata.get("node_id") for doc in results[previous_layer]]
+                    parent_node_ids = [doc.metadata.get("node_id") for doc, _ in results[previous_layer]]
                     for node_id in parent_node_ids:
-                        layer_results.extend(vectorstore[node_id].similarity_search_by_vector(
+                        layer_results.extend(vectorstore[node_id].similarity_search_with_score_by_vector(
                             query_embedding,
                             k=top_k
                         ))
                     # Take top_k - no need to sort since similarity_search_by_vector already returns sorted results
-                    results[layer] = layer_results[:top_k]
+                    results[layer] = [doc for doc, _ in sorted(layer_results, key=lambda x: x[1])][:top_k]
                 
                 # update the previous layer name
                 previous_layer = layer

--- a/core/frameworks/scaler_v1.py
+++ b/core/frameworks/scaler_v1.py
@@ -1,0 +1,357 @@
+# core/frameworks/scaler_v1.py
+
+from typing import Dict, Union, Iterable, Generator, Tuple, List, Optional
+import os
+
+from langchain_community.vectorstores import FAISS
+from langchain_core.documents import Document as LangChainDocument
+
+from core.datasets import Document as SchemaDocument
+from core.rag_core import run_doc_summary
+from core.utils import FAISSIVFCustom
+
+from core.frameworks.base import BaseRAGFramework
+from core.frameworks.schema import AVAILABLE_LAYERS, PARENT_NODE_ID
+
+class ScalerV1RAG(BaseRAGFramework):
+    """
+    SCALER(Semantic Clustered Abstractive Layers for Efficient Retrieval) framework with FAISS IVF (Inverted File) Index.
+    
+    This framework implements two-layered vector stores.
+    - Document-level vector store: each vector point represents a document summary embedding vector.
+    - Chunk-level vector store: each vector point represents a chunk embedding vector.
+
+    If a single document is assigned on index(), it will be indexed and retrieved by the FAISS brute force search or IVF (if number of chunks is greater than 10K).
+    """
+    def __init__(
+            self, 
+            config_name: str, 
+            config_path: str = "core/configs/scaler_v1_rag/test.yaml", 
+            is_save_vectorstore: bool = False
+        ):
+        super().__init__(config_name, config_path, is_save_vectorstore)
+        
+        # Intialize two layered FAISS IVFs
+        self.layered_vector_stores: Dict[AVAILABLE_LAYERS, Union[FAISS, Dict[PARENT_NODE_ID, FAISS]]] = {
+            # a single IVF for document cluster level, each vector pointrepresents a document summary embedding vector.
+            "doc": None,
+            # multiple IVFs for chunk cluster level per each document, each vector point represents a chunk embedding vector.
+            "chunk": {}
+        }
+
+    def index(
+        self,
+        docs: Union[SchemaDocument, Generator[SchemaDocument, None, None], Iterable[SchemaDocument]], 
+    ):
+        """
+        Index the documents into the two-layered vector stores.
+
+        Same process as ScalerRAG, but do not take embedding before indexing.
+        """
+        # Update vectorstore path after setting document ID
+        self.vectorstore_path = self._define_vectorstore_path(docs)
+
+        # Try to load existing indexes first
+        try:
+            loaded_layers = self._load_all_indexes()
+            if all(loaded_layers.values()):
+                self.logger.info("Successfully loaded all existing indexes")
+                return
+            elif any(loaded_layers.values()):
+                self.logger.info(f"Partially loaded indexes. Will create missing layers: {[layer for layer, loaded in loaded_layers.items() if not loaded]}")
+        except Exception as e:
+            self.logger.warning(f"Failed to load existing indexes: {str(e)}. Will create new indexes.")
+            loaded_layers = {layer: False for layer in self.layered_vector_stores.keys()}
+
+        # Ensure docs is a generator
+        gen_docs = self._ensure_document_generator(docs)
+
+        # Index document
+        try:
+            self.logger.debug("Starting document indexing")
+            # Summarize document and get embedding
+            num_docs = 0
+            doc_sum_embed = {}
+            doc_summary = {}  # doc id is key, summary is value
+            for doc in gen_docs:
+                # Skip document-level processing if doc is already loaded
+                if loaded_layers["doc"]:
+                    self.logger.info(f"Skipping processing for document {doc.id} as it's already indexed")
+                else:
+                    # Run document summary
+                    doc_summary[doc.id], doc_sum_embed[doc.id] = self._doc_summary(doc)
+                    self.logger.debug(f"Completed document {doc.id} summary")
+                
+                # Skip chunk processing if chunk already loaded for this document
+                chunk_key = str(doc.id)
+                if chunk_key in self.layered_vector_stores["chunk"] or any(k.startswith(chunk_key + "-") for k in self.layered_vector_stores["chunk"].keys()):
+                    self.logger.info(f"Skipping chunk processing for document {chunk_key} as it's already indexed")
+                else:
+                    # Chunking
+                    chunks, chunks_embed = self._doc_chunking(doc)
+                    # Create layered vector store
+                    self._layered_vector_store(
+                        layer="chunk",
+                        embeddings=chunks_embed,
+                        chunks=chunks,
+                        parent_node_id=doc.id
+                    )
+                    self.logger.debug(f"Completed chunking for document {chunk_key}")
+                num_docs += 1
+
+            # Create or update document summary vector store if we have multiple documents
+            if num_docs > 1 and doc_summary:
+                # Always recreate the doc and doc_cc layers when adding new documents
+                # This ensures proper clustering with all documents
+                self._layered_vector_store(
+                    layer="doc",
+                    embeddings=[doc_sum_embed[doc_id] for doc_id in doc_summary.keys()],
+                    doc_summary=doc_summary,
+                    parent_node_id=None
+                )
+                self.logger.debug(f"Completed document summary vector store")
+
+            # Save all indexes if enabled
+            if self.is_save_vectorstore:
+                self._save_all_indexes()
+            
+            self.logger.info("Indexing complete")
+                    
+
+        except Exception as e:
+            self.logger.error(f"Error during indexing: {str(e)}")
+            raise
+
+    def _doc_summary(self, doc: SchemaDocument) -> Tuple[str, List[float]]:
+        """
+        Summarize document and get embedding
+        """
+        with self.profiler.track("index.doc_summary"):
+            summary = run_doc_summary(doc.content)
+
+        # Get embeddings
+        embedding = self.llm.embedding.embed_documents([summary])        
+        return summary, embedding[0]
+        
+    def _doc_chunking(self, doc: SchemaDocument) -> Tuple[List[LangChainDocument], List[List[float]]]:
+        """
+        Chunk document
+        """
+        with self.profiler.track("index.chunking"):
+            chunks = self.chunker.run([doc], mode=self.chunker_config.mode)
+        # Get embeddings
+        embeddings = self.llm.embedding.embed_documents([chunk.page_content for chunk in chunks])
+        return chunks, embeddings
+
+    def _layered_vector_store(
+        self, 
+        layer: AVAILABLE_LAYERS, 
+        embeddings: List[List[float]],
+        doc_summary: Optional[Dict[PARENT_NODE_ID, str]] = None,
+        chunks: Optional[List[LangChainDocument]] = None,
+        parent_node_id: Optional[PARENT_NODE_ID] = None
+    ):
+        """Create two layered IVFs for efficient retrieval."""
+
+        # If no clustering is configured, store all embeddings in a single vector store
+        texts_and_embeddings = []
+        metadatas = []
+
+        # For document layer, match embeddings with doc_summary dictionary entries
+        if layer == "doc":
+            for doc_id, embedding in zip(doc_summary.keys(), embeddings):
+                texts_and_embeddings.append((doc_summary[doc_id], embedding))
+                metadatas.append({"layer": layer, "node_id": doc_id})
+
+            # Add vector store to the layer
+            self.layered_vector_stores[layer] = FAISSIVFCustom.from_embeddings(
+                text_embeddings=texts_and_embeddings,
+                metadatas=metadatas,
+                embedding=self.llm.get_embedding
+            )
+
+        # For chunk layer, use the existing approach
+        elif layer == "chunk":
+            for idx, embedding in enumerate(embeddings):
+                texts_and_embeddings.append((chunks[idx].page_content, embedding))
+                metadatas.append({"layer": layer, **chunks[idx].metadata})
+            
+            # Add vector store to the layer
+            self.layered_vector_stores[layer][parent_node_id] = FAISSIVFCustom.from_embeddings(
+                text_embeddings=texts_and_embeddings,
+                metadatas=metadatas,
+                embedding=self.llm.get_embedding
+            )
+
+        else:
+            raise ValueError(f"Invalid layer: {layer}")
+
+    def _save_all_indexes(self):
+        """Save all indexes to disk."""
+        if not self.is_save_vectorstore:
+            self.logger.info("Skipping index saving as is_save_vectorstore is False")
+            return
+            
+        try:
+            self.logger.debug("Starting to save all indexes")
+            
+            # Create base directory if it doesn't exist
+            os.makedirs(self.vectorstore_path, exist_ok=True)
+            
+            # Save each layer
+            for layer, vector_store in self.layered_vector_stores.items():
+                if vector_store is None:
+                    continue
+                    
+                # Create layer directory
+                layer_path = os.path.join(self.vectorstore_path, layer)
+                os.makedirs(layer_path, exist_ok=True)
+                
+                # Detect layer type dynamically based on the data structure
+                if isinstance(vector_store, dict):
+                    # Handle dictionary of FAISS instances (typically chunk layer)
+                    for node_id, vs in vector_store.items():
+                        if vs is not None:
+                            save_path = os.path.join(layer_path, f"{node_id}.faiss")
+                            vs.save_local(save_path)
+                            self.logger.debug(f"Saved {layer} index for node {node_id} to {save_path}")
+                else:
+                    # Handle single FAISS instance (typically doc layer)
+                    save_path = os.path.join(layer_path, f"{layer}.faiss")
+                    vector_store.save_local(save_path)
+                    self.logger.debug(f"Saved {layer} index to {save_path}")
+            
+            self.logger.info("Successfully saved all indexes")
+            
+        except Exception as e:
+            self.logger.error(f"Error saving indexes: {str(e)}")
+            raise
+
+    def _load_all_indexes(self) -> Dict[str, bool]:
+        """
+        Load all indexes from disk.
+                
+        Returns:
+            Dict[str, bool]: Dictionary indicating which layers were successfully loaded
+        """
+        try:
+            self.logger.debug("Starting to load all indexes")
+            
+            # Check if the base directory exists
+            if not os.path.exists(self.vectorstore_path):
+                self.logger.info(f"No existing indexes found at {self.vectorstore_path}")
+                return {layer: False for layer in self.layered_vector_stores.keys()}
+            
+            # Track which layers were loaded
+            loaded_layers = {layer: False for layer in self.layered_vector_stores.keys()}
+            
+            # Load each layer based on its expected structure (from self.layered_vector_stores)
+            for layer, store_structure in self.layered_vector_stores.items():
+                layer_path = os.path.join(self.vectorstore_path, layer)
+                
+                if not os.path.exists(layer_path):
+                    self.logger.debug(f"No index directory found for layer {layer}")
+                    continue
+                
+                # Determine if this layer should be a dictionary or single instance based on its initial structure
+                if isinstance(store_structure, dict):
+                    # Get all .faiss files in the directory
+                    faiss_files = [f for f in os.listdir(layer_path) if f.endswith('.faiss')]
+                    if faiss_files:  # Only mark as loaded if we found some files
+                        loaded_layers[layer] = True
+                        for faiss_file in faiss_files:
+                            node_id = faiss_file[:-6]  # Remove .faiss extension
+                            index_path = os.path.join(layer_path, faiss_file)
+                            self.layered_vector_stores[layer][node_id] = FAISSIVFCustom.load_local(
+                                index_path,
+                                self.llm.get_embedding,
+                                allow_dangerous_deserialization=True
+                            )
+                            self.logger.debug(f"Loaded {layer} index for node {node_id} from {index_path}")
+                else:
+                    # This is a single instance layer (like "doc")
+                    index_path = os.path.join(layer_path, f"{layer}.faiss")
+                    if os.path.exists(index_path):
+                        self.layered_vector_stores[layer] = FAISSIVFCustom.load_local(
+                            index_path,
+                            self.llm.get_embedding,
+                            allow_dangerous_deserialization=True
+                        )
+                        self.logger.debug(f"Loaded {layer} index from {index_path}")
+                        loaded_layers[layer] = True
+            
+            loaded_count = sum(loaded_layers.values())
+            if loaded_count == 0:
+                self.logger.info("No indexes were loaded")
+            else:
+                self.logger.info(f"Successfully loaded {loaded_count} layers: {[layer for layer, loaded in loaded_layers.items() if loaded]}")
+            
+            return loaded_layers
+            
+        except Exception as e:
+            self.logger.error(f"Error loading indexes: {str(e)}")
+            raise
+
+    def retrieve(
+        self, 
+        query: str, 
+        top_k_per_layer: Optional[Dict[AVAILABLE_LAYERS, int]] = None, 
+    ) -> Dict[AVAILABLE_LAYERS, List[LangChainDocument]]:
+        """
+        Retrieve relevant documents using SCALER's hierarchical approach.
+        
+        This method:
+        1. Retrieves top_k documents from the top node FAISS vector store.
+        2. For each retrieved document, retrieves top_k chunks from the corresponding chunk node FAISS vector store.
+        """
+        try:
+            self.logger.debug(f"Starting retrieval for query: {query}")
+            
+            # Use config's top_k if not specified
+            if top_k_per_layer is None:
+                config = self.retrieval_generation_config
+                top_k_per_layer = {
+                    "doc": getattr(config, "top_k_doc", None) or 5,
+                    "chunk": getattr(config, "top_k", None) or 10
+                }
+            # Get the query embedding
+            query_embedding = self.llm.embedding.embed_query(query)
+            results = {}
+            previous_layer = None
+            for layer, top_k in top_k_per_layer.items():
+                # Skip if the vectorstore is not created
+                if not self.layered_vector_stores.get(layer, None):
+                    continue
+
+                vectorstore = self.layered_vector_stores[layer]
+                self.logger.debug(f"Processing {layer} layer")
+
+                # if vectorsore is a single FAISS instance, use similarity_search_with_score
+                if isinstance(vectorstore, FAISS):
+                    results[layer] = vectorstore.similarity_search_by_vector(
+                        query_embedding,
+                        k=top_k
+                    )
+                
+                # if vectorsore is a dictionary of FAISS instances, use similarity_search_with_score_by_vector
+                elif isinstance(vectorstore, dict):
+                    # Initialize the results for the current layer
+                    layer_results = []
+                    # get the parent node ides from the previous layer
+                    parent_node_ids = [doc.metadata.get("node_id") for doc in results[previous_layer]]
+                    for node_id in parent_node_ids:
+                        layer_results.extend(vectorstore[node_id].similarity_search_by_vector(
+                            query_embedding,
+                            k=top_k
+                        ))
+                    # Take top_k - no need to sort since similarity_search_by_vector already returns sorted results
+                    results[layer] = layer_results[:top_k]
+                
+                # update the previous layer name
+                previous_layer = layer
+
+            return results["chunk"]
+
+        except Exception as e:
+            self.logger.error(f"Error during retrieval: {str(e)}")
+            raise

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,6 +1,7 @@
 # core/utils/__init__.py
 
 from .libs.huggingface import load_hf_dataset
+from .libs.custom_faiss import FAISSIVFCustom
 from .path import get_project_root
 from .profiler import Profiler
 from .process_bar import ProgressTracker
@@ -8,6 +9,7 @@ from .ml_io import save_layer_models, load_layer_models
 
 __all__ = [
     "load_hf_dataset",
+    "FAISSIVFCustom",
     "get_project_root",
     "Profiler",
     "ProgressTracker",

--- a/core/utils/libs/custom_faiss.py
+++ b/core/utils/libs/custom_faiss.py
@@ -1,0 +1,98 @@
+# core/utils/libs/custom_faiss.py
+import numpy as np
+from typing import List, Dict, Tuple, Optional, Any, Iterable
+import uuid
+import warnings
+import torch
+
+import faiss
+from langchain_community.vectorstores import FAISS
+from langchain_core.embeddings import Embeddings
+from langchain_core.documents import Document
+from langchain_community.docstore.in_memory import InMemoryDocstore
+
+# Suppress semaphore leak warnings
+warnings.filterwarnings("ignore", message=".*resource_tracker: There appear to be .* leaked semaphore objects to clean up at shutdown.*")
+
+# Limit number of threads to prevent threading issues
+torch.set_num_threads(1)
+
+class FAISSIVFCustom(FAISS):
+    """Custom FAISS implementation with IVF configuration based on dataset size."""
+    
+    @classmethod
+    def from_embeddings(
+        cls,
+        text_embeddings: Iterable[Tuple[str, List[float]]],
+        embedding: Embeddings,
+        metadatas: Optional[Iterable[dict]] = None,
+        ids: Optional[List[str]] = None,
+        nlist: Optional[int] = None,
+        **kwargs: Any,
+    ) -> FAISS:
+        """Create FAISS instance with custom IVF configuration based on dataset size"""
+        
+        # Extract texts and embeddings
+        texts = []
+        embeddings = []
+        for text, embedding_vector in text_embeddings:
+            texts.append(text)
+            embeddings.append(embedding_vector)
+        
+        # Get embedding dimension
+        dim = len(embeddings[0]) if embeddings else 0
+        
+        # Create a FAISS index - using conservative settings for memory usage
+        if len(embeddings) > 10000 and dim > 0:  # Only use IVF for larger collections
+            if nlist is None:
+                # Use a more conservative nlist value to reduce memory usage
+                nlist = min(1024, max(4, int(4 * np.sqrt(len(embeddings)))))
+                
+            # Create quantizer for IVF
+            quantizer = faiss.IndexFlatL2(dim)
+            # Create the IVF index
+            index = faiss.IndexIVFFlat(quantizer, dim, nlist)
+            
+            # Train the index (required for IVF)
+            if not index.is_trained and len(embeddings) > nlist:
+                # Convert to numpy array once to avoid multiple conversions
+                embeddings_array = np.array(embeddings, dtype=np.float32)
+                index.train(embeddings_array)
+                # Add embeddings to the index
+                if len(embeddings) > 0:
+                    index.add(embeddings_array)
+        else:
+            # For smaller collections, use a flat index
+            index = faiss.IndexFlatL2(dim)
+            # Add embeddings to the index
+            if len(embeddings) > 0:
+                index.add(np.array(embeddings, dtype=np.float32))
+        
+        # Create the docstore and mapping
+        docstore = InMemoryDocstore({})
+        index_to_docstore_id = {}
+        
+        # Process texts, embeddings, and metadata
+        metadatas = metadatas or [{} for _ in texts]
+        for i, (text, metadata) in enumerate(zip(texts, metadatas)):
+            doc_id = ids[i] if ids and i < len(ids) else str(uuid.uuid4())
+            docstore.add({doc_id: Document(page_content=text, metadata=metadata)})
+            index_to_docstore_id[i] = doc_id
+        
+        # Return the FAISS instance
+        return cls(
+            embedding.embed_query,
+            index,
+            docstore,
+            index_to_docstore_id,
+            **kwargs
+        )
+        
+    def __del__(self):
+        """Ensure proper resource cleanup when object is deleted."""
+        try:
+            if hasattr(self, 'index') and self.index is not None:
+                # Reset the FAISS index to release resources
+                self.index.reset()
+        except:
+            pass

--- a/core/utils/libs/custom_faiss.py
+++ b/core/utils/libs/custom_faiss.py
@@ -81,7 +81,7 @@ class FAISSIVFCustom(FAISS):
         
         # Return the FAISS instance
         return cls(
-            embedding.embed_query,
+            embedding,
             index,
             docstore,
             index_to_docstore_id,

--- a/experiments/base.py
+++ b/experiments/base.py
@@ -15,7 +15,7 @@ from typing import List
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from core.frameworks import SimpleRAG, ScalerRAG, RAGResponse
+from core.frameworks import SimpleRAG, ScalerRAG, ScalerV1RAG, RAGResponse
 from core.datasets import IntraDocumentQA, InterDocumentQA
 from core.logger.logger import get_logger
 from core.evaluation.metrics_summary import accumulate_and_summarize_metrics
@@ -44,6 +44,9 @@ def run_experiment(
         elif Path(config_path).parent.name == "scaler_rag":
             logger.info(f"Initializing ScalerRAG for {config_name}")
             rag = ScalerRAG(config_name, config_path, True)
+        elif Path(config_path).parent.name == "scaler_v1_rag":
+            logger.info(f"Initializing ScalerV1RAG for {config_name}")
+            rag = ScalerV1RAG(config_name, config_path, True)
         else:
             raise ValueError(f"Invalid config path: {config_path}. Must be in the simple_rag directory.")
 
@@ -150,6 +153,14 @@ if __name__ == "__main__":
         # run the scaler_rag experiment
         config_path = "core/configs/scaler_rag/test.yaml"
         config_name = ["TEST02_scaler_rag_01", "TEST02_scaler_rag_02"]
+        for config in config_name:
+            print(f"\n===== Starting {config} test =====")
+            run_experiment(config_path, config, llm_generation=True)
+            print(f"\n===== {config} test completed =====")
+
+        # run the scaler_v1_rag experiment
+        config_path = "core/configs/scaler_v1_rag/test.yaml"
+        config_name = ["TEST02_scaler_v1_rag_01", "TEST02_scaler_v1_rag_02"]
         for config in config_name:
             print(f"\n===== Starting {config} test =====")
             run_experiment(config_path, config, llm_generation=True)

--- a/experiments/main.py
+++ b/experiments/main.py
@@ -52,6 +52,14 @@ def run_scaler_rag_dim_reduction():
         run_experiment(config_path, config)
         print(f"\n===== {config} test completed =====")
 
+def run_scaler_v1_rag_comparison():
+    config_path = "core/configs/scaler_v1_rag/comparison.yaml"
+    config_names = ["scaler_v1_rag_01_01", "scaler_v1_rag_01_02", "scaler_v1_rag_01_03"]
+    # run the scaler_v1_rag experiment
+    for config in config_names:
+        print(f"\n===== Starting {config} test =====")
+        run_experiment(config_path, config)
+        print(f"\n===== {config} test completed =====")
 
 if __name__ == "__main__":
     # run experiments
@@ -60,3 +68,4 @@ if __name__ == "__main__":
     # run_scaler_rag_sentences()
     # run_scaler_rag_reasoning()
     # run_scaler_rag_dim_reduction()
+    # run_scaler_v1_rag_comparison()

--- a/test/scaler_v1_rag.py
+++ b/test/scaler_v1_rag.py
@@ -1,0 +1,87 @@
+# test/scaler_v1_rag.py
+
+"""
+SCALER V1 RAG test
+Run the script to debug;
+```
+python -m pdb test/scaler_v1_rag.py
+```
+"""
+
+import sys
+import os
+import gc
+import warnings
+import json
+import yaml
+from pathlib import Path
+from typing import List, Dict
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from core.frameworks import ScalerV1RAG, RAGResponse
+from core.logger.logger import get_logger
+from core.evaluation.metrics_summary import accumulate_and_summarize_metrics, MetricsSummary
+
+from langchain_core.documents import Document as LangChainDocument
+
+# Set up logging
+logger = get_logger(__name__)
+
+def multihoprag_test():
+    try:
+        # Initialize RAG
+        logger.info("Initializing SCALER V1 RAG")
+        scaler_v1_rag = ScalerV1RAG("TEST_scaler_v1_rag_multihoprag", is_save_vectorstore=True)
+        gen_docs, gen_qas = scaler_v1_rag.load_dataset()
+
+        # Index documents
+        logger.info("Indexing documents")
+        scaler_v1_rag.index(gen_docs)
+        logger.info("Indexing completed")
+
+        # Test retrieval and generation
+        logger.info("Testing RAG with queries")
+        all_responses, all_metrics = scaler_v1_rag.run(gen_qas) 
+        logger.info("RAG test completed")
+
+        # Build overall metrics summary
+        overall_metrics_summary, detailed_df = accumulate_and_summarize_metrics(
+            metrics_list=all_metrics,
+            profiler_metrics=scaler_v1_rag.profiler.get_metrics()
+        ) 
+
+        # print the metrics
+        print(scaler_v1_rag.profiler.get_metrics(include_counts=True))
+        
+        # store the response_list in a json file, use it for evaluation test
+        response_dir = Path("test/input_data")
+        response_dir.mkdir(parents=True, exist_ok=True)
+        response_file = response_dir / f"RAGResponse_scaler_v1_multihoprag_test.json"
+        with open(response_file, 'w') as f:
+            json.dump([response.model_dump() for response in all_responses], f, indent=2)
+
+        # save the metrics summary
+        output_dir = Path("test/output_data")
+        output_dir.mkdir(parents=True, exist_ok=True)
+        metrics_summary_file = output_dir / f"scaler_v1_multihoprag_overall_metrics_summary.json"
+        with open(metrics_summary_file, 'w') as f:
+            json.dump(overall_metrics_summary.model_dump(), f, indent=2)
+
+        # save the detailed dataframe
+        detailed_df_file = output_dir / f"scaler_v1_multihoprag_detailed_metrics_summary.csv"
+        detailed_df.to_csv(detailed_df_file, index=False)
+
+    except Exception as e:
+        logger.error(f"Error occurred: {e}")
+        raise
+    finally:
+        gc.collect()
+
+if __name__ == "__main__":
+    import time
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore")
+        multihoprag_test()
+        print("\n===== multihoprag_test completed =====")
+        print("start comparison test in 3 seconds...")
+        time.sleep(3)


### PR DESCRIPTION
## 📝 Description
This PR implements a simplified version of the SCALER framework (ScalerV1RAG) for inter-document search. The implementation provides a more streamlined approach to hierarchical retrieval while maintaining the core functionality of the original SCALER framework.

## 🔄 Type of Change
- [x] ✨ New feature (non-breaking change that adds functionality)

## 🧪 Testing
- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Testing

## 📸 Key Implementation Details
- Added new `ScalerV1RAG` class that implements a simplified two-layered vector store approach
- Created configuration files for comparison testing against the original SCALER implementation
- Added support for efficient document-level and chunk-level retrieval
- Implemented index saving and loading functionality for persistence
- Added custom FAISS utility for improved vector search
