### PR TITLE
fix: Fix configuration comments in RAG experiment configs

### DIFF
--- a/core/configs/scaler_rag/scaler01_sentence_chunk.yaml
+++ b/core/configs/scaler_rag/scaler01_sentence_chunk.yaml
@@ -1,11 +1,9 @@
 # core/configs/scaler_rag/scaler01_sentence_chunk.yaml
 
-""" 
-Compare the performance of sentence chunking for RAG.
-- whether the sentence chunking is better than the fixed chunking
-
-Tested for both IntraDocumentQA (Qasper) and InterDocumentQA (Frames).
-"""
+# Compare the performance of sentence chunking for RAG.
+# - whether the sentence chunking is better than the fixed chunking
+#
+# Tested for both IntraDocumentQA (Qasper) and InterDocumentQA (Frames).
 
 # IntraDocumentQA & Fixed Chunking
 scaler_rag_01_01:

--- a/core/configs/scaler_rag/scaler02_reasoning_model.yaml
+++ b/core/configs/scaler_rag/scaler02_reasoning_model.yaml
@@ -1,12 +1,10 @@
 # core/configs/scaler_rag/scaler02_reasoning_model.yaml
 
-""" 
-Compare the performance of different LLMs for RAG.
-- whether the reasoning model is better than the normal model
-- whether the large model is better than the small model
-
-Tested on IntraDocumentQA (Qasper) and InterDocumentQA (Frames).
-"""
+# Compare the performance of different LLMs for RAG.
+# - whether the reasoning model is better than the normal model
+# - whether the large model is better than the small model
+#
+# Tested on IntraDocumentQA (Qasper) and InterDocumentQA (Frames).
 
 # Reasoning Model
 #  IntraDocumentQA (Qasper)

--- a/core/configs/scaler_rag/scaler03_dim_reduction.yaml
+++ b/core/configs/scaler_rag/scaler03_dim_reduction.yaml
@@ -1,8 +1,6 @@
 # core/configs/scaler_rag/scaler03_dim_reduction.yaml
 
-""" 
-Compare the performance of dimensionality reduction for RAG.
-"""
+# Compare the performance of dimensionality reduction for RAG.
 
 # IntraDocumentQA & no dimensionality reduction
 scaler_rag_03_01:

--- a/core/configs/simple_rag/rag01_sentence_chunk.yaml
+++ b/core/configs/simple_rag/rag01_sentence_chunk.yaml
@@ -1,11 +1,9 @@
 # core/configs/rag_sentence_chunk.yaml
 
-""" 
-Compare the performance of sentence chunking for RAG.
-- whether the sentence chunking is better than the fixed chunking
-
-Tested for both IntraDocumentQA (Qasper) and InterDocumentQA (Frames).
-"""
+# Compare the performance of sentence chunking for RAG.
+# - whether the sentence chunking is better than the fixed chunking
+#
+# Tested for both IntraDocumentQA (Qasper) and InterDocumentQA (Frames).
 
 # IntraDocumentQA & Fixed Chunking
 simple_rag_01_01:

--- a/core/configs/simple_rag/rag02_reasoning_model.yaml
+++ b/core/configs/simple_rag/rag02_reasoning_model.yaml
@@ -1,12 +1,10 @@
 # core/configs/rag_reasoning_model.yaml
 
-""" 
-Compare the performance of different LLMs for RAG.
-- whether the reasoning model is better than the normal model
-- whether the large model is better than the small model
-
-Tested on IntraDocumentQA (qasper) & InterDocumentQA (Frames).
-"""
+# Compare the performance of different LLMs for RAG.
+# - whether the reasoning model is better than the normal model
+# - whether the large model is better than the small model
+#
+# Tested on IntraDocumentQA (qasper) & InterDocumentQA (Frames).
 
 #  IntraDocumentQA & Llama3.1 (8B) -> same as simple_rag_01_02
 


### PR DESCRIPTION
## 📝 Description
Fixed YAML parsing errors by converting Python-style triple-quoted comments (`"""`) to proper YAML comments using `#` in all configuration files.

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 🧪 Testing
- [x] Manual Testing - Successfully ran `python -m experiments.main` without YAML parsing errors
