### PR TITLE
fix: add the schema error in chunking

### DIFF
--- a/core/frameworks/schema.py
+++ b/core/frameworks/schema.py
@@ -45,7 +45,7 @@ class ClusteringConfig(BaseModel):
 
 class ChunkerConfig(BaseModel):
     """Configuration for the text chunking component."""
-    mode: Literal["fixed"] = Field(..., description="Chunking mode (currently only fixed is supported)")
+    mode: Literal["fixed", "sentence"] = Field(..., description="Chunking mode (fixed or sentence-based chunking)")
     size: PositiveInt = Field(..., description="Size of each chunk in tokens or characters")
     overlap: float = Field(
         ..., 


### PR DESCRIPTION
## 📝 Description
This PR adds support for sentence-based chunking in the RAG system by updating the schema definition to allow 'sentence' as a valid chunking mode in the `ChunkerConfig` class.

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 📌 Additional Notes
The chunker implementation in `core/rag_core/indexing/chunker.py` already supported both 'fixed' and 'sentence' modes, but the schema definition in `core/frameworks/schema.py` only allowed 'fixed' mode. This PR updates the schema to match the implementation, allowing experiments with sentence-based chunking to run successfully.
