### PR TITLE
fix: Fix clustering error for single sample documents

### DIFF
--- a/core/rag_core/indexing/clustering.py
+++ b/core/rag_core/indexing/clustering.py
@@ -114,7 +114,9 @@ def run_clustering(
     
     # default cluster numbers
     if not n_clusters and not items_per_cluster:
-        if len(embeddings_array) < 50:
+        if len(embeddings_array) < 10:
+            n_clusters = 1
+        elif len(embeddings_array) < 50:
             n_clusters = 5
         else:
             n_clusters = 10
@@ -123,16 +125,16 @@ def run_clustering(
     # Estimate number of clusters if not provided
     if not n_clusters and items_per_cluster:
         # Calculate based on desired items per cluster (as a guideline)
-        n_clusters = max(2, min(len(embeddings_array) // items_per_cluster, 10))
+        if len(embeddings_array) < 10:
+            n_clusters = 1
+        else:
+            n_clusters = max(2, min(len(embeddings_array) // items_per_cluster, 10))
         logger.info(f"Estimated {n_clusters} clusters for {len(embeddings_array)} items (target guideline: ~{items_per_cluster} items/cluster)")
     
-    # Check if we have enough samples for the requested number of clusters
-    if len(embeddings_array) < n_clusters:
-        logger.warning(f"Not enough samples ({len(embeddings_array)}) for requested clusters ({n_clusters}). Reducing clusters to match sample count.")
-        if len(embeddings_array) <= 1:
-            logger.warning("Only one sample available, clustering not possible. Returning None.")
-            return None
-        n_clusters = len(embeddings_array)
+    # Special case for single sample
+    if len(embeddings_array) <= 1:
+        logger.warning("Only one sample available, clustering not possible. Returning None.")
+        return None
     
     # Apply clustering based on method
     if method.lower() == "kmeans":

--- a/core/rag_core/indexing/clustering.py
+++ b/core/rag_core/indexing/clustering.py
@@ -133,8 +133,22 @@ def run_clustering(
     
     # Special case for single sample
     if len(embeddings_array) <= 1:
-        logger.warning("Only one sample available, clustering not possible. Returning None.")
-        return None
+        logger.info("Only one sample available. Creating a single cluster.")
+        if method.lower() == "kmeans":
+            # Create a KMeans instance with 1 cluster
+            kmeans = KMeans(n_clusters=1, random_state=kwargs.get("random_state", 42), n_init=10)
+            # For a single sample, we need to manually set the attributes
+            kmeans.cluster_centers_ = np.array([embeddings_array[0]])
+            kmeans.labels_ = np.array([0])
+            logger.info("Created KMeans with 1 cluster for single sample")
+            return kmeans
+        elif method.lower() == "gmm":
+            # Create a GMM instance with 1 component
+            gmm = GaussianMixture(n_components=1, random_state=kwargs.get("random_state", 42))
+            # For a single sample, we need to manually set the attributes
+            gmm.means_ = np.array([embeddings_array[0]])
+            logger.info("Created GMM with 1 component for single sample")
+            return gmm
     
     # Apply clustering based on method
     if method.lower() == "kmeans":


### PR DESCRIPTION
## 📝 Description
This PR fixes an issue with clustering when there's only one sample available. Previously, the system would fail with an error when trying to cluster a single sample. Now, it gracefully handles this case by creating a single cluster for the sample.

## 🔗 Related Issue(s)
- #47 
- #44 
- #40 

## 🔄 Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## 📌 Additional Notes
The changes include:

1. Modified the clustering algorithm to use only 1 cluster when there are fewer than 10 samples
2. Added special handling for the single sample case to manually create a KMeans or GMM instance with appropriate attributes
3. Updated log messages to be more informative

This fix ensures that documents with very few chunks can still be processed through the clustering pipeline without errors.